### PR TITLE
macOS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "TinyStorage",
-    platforms: [.iOS(.v17), .tvOS(.v17), .visionOS(.v1), .watchOS(.v10)],
+    platforms: [.iOS(.v17), .tvOS(.v17), .visionOS(.v1), .watchOS(.v10), .macOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(


### PR DESCRIPTION
Updating Package.swift to specify minimum macOS requirement (`.v14`). Tested on a real device.